### PR TITLE
feat: add planning poker ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ target
 
 # other
 *.secure.properties
+
+# Node modules
+node_modules/
+**/node_modules/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Planning Poker</title>
+  </head>
+  <body class="bg-gray-900 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "planning-poker-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,30 @@
+import Header from './components/Header.jsx'
+import TaskList from './components/TaskList.jsx'
+import Content from './components/Content.jsx'
+import Participants from './components/Participants.jsx'
+import Footer from './components/Footer.jsx'
+
+// Root application component assembling page layout
+export default function App() {
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col">
+      {/* Header with navigation */}
+      <Header />
+
+      {/* Main responsive layout */}
+      <main className="flex-1 container mx-auto p-4 md:p-8">
+        <div className="grid gap-4 lg:grid-cols-3">
+          {/* Left column with tasks */}
+          <TaskList />
+          {/* Middle column with active task and cards */}
+          <Content />
+          {/* Right column with participants */}
+          <Participants />
+        </div>
+      </main>
+
+      {/* Footer */}
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -1,0 +1,11 @@
+// Single card button used in voting deck
+export default function Card({ value }) {
+  return (
+    <button
+      className="aspect-square bg-gray-700 rounded flex items-center justify-center text-lg font-semibold hover:bg-gray-600 transition-colors"
+      title={`Карта ${value}`}
+    >
+      {value}
+    </button>
+  )
+}

--- a/frontend/src/components/Content.jsx
+++ b/frontend/src/components/Content.jsx
@@ -1,0 +1,36 @@
+import Card from './Card.jsx'
+
+// Central area with active task description and voting deck
+export default function Content() {
+  const deck = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+
+  return (
+    <section className="bg-gray-800 rounded-lg p-4 flex flex-col">
+      <div>
+        <h2 className="text-xl mb-2">Тема</h2>
+        <p className="text-sm text-gray-400 mb-4">Описание</p>
+        <p className="text-sm mb-4">Автор: Иванов И.</p>
+        <a href="#" className="text-blue-400 hover:underline text-sm">
+          Jira link
+        </a>
+      </div>
+
+      {/* Voting deck */}
+      <div className="mt-6 flex-1">
+        <div className="grid grid-cols-5 gap-2 mb-4">
+          {deck.map(n => (
+            <Card key={n} value={n} />
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded transition-colors">
+            Начать голосование
+          </button>
+          <button className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded transition-colors">
+            Показать карты
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,8 @@
+// Simple footer
+export default function Footer() {
+  return (
+    <footer className="text-center text-xs text-gray-500 py-4">
+      &copy; {new Date().getFullYear()} Planning Poker
+    </footer>
+  )
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+
+// Top navigation bar with brand and responsive burger menu
+export default function Header() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <header className="bg-gray-800 px-4 py-3 flex items-center justify-between relative">
+      <a href="#" className="font-semibold text-lg">Planning Poker</a>
+
+      {/* Desktop navigation */}
+      <nav className="hidden md:flex gap-4 items-center">
+        <a href="#" className="hover:text-blue-400">Room-1234</a>
+      </nav>
+
+      {/* Burger menu for mobile */}
+      <button
+        className="md:hidden text-2xl"
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle menu"
+      >
+        {open ? '✖' : '☰'}
+      </button>
+
+      {/* Dropdown menu shown on small screens */}
+      {open && (
+        <div className="md:hidden absolute top-full left-0 right-0 bg-gray-800 p-4 shadow-lg">
+          <a
+            href="#"
+            className="block py-1 hover:text-blue-400"
+            onClick={() => setOpen(false)}
+          >
+            Room-1234
+          </a>
+        </div>
+      )}
+    </header>
+  )
+}

--- a/frontend/src/components/Participants.jsx
+++ b/frontend/src/components/Participants.jsx
@@ -1,0 +1,25 @@
+// Right column with participants avatars
+const participants = [
+  { id: 1, name: 'Гость', avatar: '🙂' },
+  { id: 2, name: 'Гость', avatar: '🙃' },
+  { id: 3, name: 'Гость', avatar: '😎' },
+]
+
+export default function Participants() {
+  return (
+    <aside className="bg-gray-800 rounded-lg p-4">
+      <h2 className="text-lg mb-4">Участники</h2>
+      <div className="flex -space-x-2">
+        {participants.map(p => (
+          <span
+            key={p.id}
+            title={p.name}
+            className="w-10 h-10 bg-gray-700 rounded-full flex items-center justify-center text-xl border-2 border-gray-800 hover:scale-105 transition"
+          >
+            {p.avatar}
+          </span>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -1,0 +1,25 @@
+// Sidebar list of tasks
+const tasks = [
+  { id: 1, title: 'Тема задания 1', author: 'Иванов И.', active: false },
+  { id: 2, title: 'Тема', author: 'Иванов И.', active: true },
+]
+
+export default function TaskList() {
+  return (
+    <aside className="bg-gray-800 rounded-lg p-4 space-y-2">
+      <h2 className="text-lg mb-2">Темы задания</h2>
+      {tasks.map(task => (
+        <a
+          key={task.id}
+          href="#"
+          className={`block p-2 rounded hover:bg-gray-700 transition ${
+            task.active ? 'bg-gray-700' : ''
+          }`}
+        >
+          <div className="font-medium">{task.title}</div>
+          <div className="text-xs text-gray-400">Автор: {task.author}</div>
+        </a>
+      ))}
+    </aside>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './index.css'
+
+// Render root React component
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add responsive React + Tailwind frontend for planning poker
- include components for header, tasks, content, participants and footer
- ignore node_modules in git

## Testing
- `mvn test` *(fails: 'dependencies.dependency[...] is referencing itself')*

------
https://chatgpt.com/codex/tasks/task_e_68a7748f636483228287a924f31a47c1