### PR TITLE
Expose RoomEntity fields with getters/setters

### DIFF
--- a/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/entity/RoomEntity.java
+++ b/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/entity/RoomEntity.java
@@ -3,11 +3,7 @@ package com.zherikhov.planningpoker.infrastructure.persistence.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 @Entity
 @Table(name = "rooms")
 public class RoomEntity {
@@ -25,6 +21,30 @@ public class RoomEntity {
     public RoomEntity(String id, String name, String status) {
         this.id = id;
         this.name = name;
+        this.status = status;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
         this.status = status;
     }
 


### PR DESCRIPTION
## Summary
- Remove Lombok from `RoomEntity` and add explicit getters and setters for `id`, `name`, and `status`

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aaee05e0e88322880d7b832e376b11