### PR TITLE
feat: add logout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Planning Poker is a web-based tool for agile teams to estimate the effort of use
 - Mobile-friendly interface and optional voice commands for quick voting.
 
 This repository contains the backend implementation built with Java and Spring Boot. See `src/` for source code and the `backend` module for service configuration.
+
+## Authentication
+
+- `POST /api/auth/login` issues an access token and optional refresh cookie.
+- `POST /api/auth/logout` clears the refresh token cookie and should be called when the user signs out.

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -25,9 +25,23 @@ export function login(remember = false) {
   storage.setItem('auth', 'true')
 }
 
-export function logout() {
-  localStorage.removeItem('auth')
-  sessionStorage.removeItem('auth')
+export async function logout() {
+  let error = null
+  try {
+    const res = await fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (!res.ok && res.status !== 401) {
+      error = new Error('logout failed')
+    }
+  } catch (e) {
+    error = e
+  } finally {
+    localStorage.removeItem('auth')
+    sessionStorage.removeItem('auth')
+  }
+  if (error) throw error
 }
 
 export function isAuthenticated() {

--- a/frontend/src/auth.test.js
+++ b/frontend/src/auth.test.js
@@ -4,15 +4,30 @@ import { login, logout, isAuthenticated, ensureAuth } from './auth.js'
 
 // Test authentication utilities
 
-test('login and isAuthenticated', () => {
-  logout()
+test('login and isAuthenticated', async () => {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = async () => ({ ok: true, status: 204 })
+  await logout().catch(() => {})
   assert.strictEqual(isAuthenticated(), false)
   login()
   assert.strictEqual(isAuthenticated(), true)
+  globalThis.fetch = realFetch
 })
 
-test('ensureAuth builds redirect path', () => {
-  logout()
+test('ensureAuth builds redirect path', async () => {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = async () => ({ ok: true, status: 204 })
+  await logout().catch(() => {})
   const redirect = ensureAuth('/boards')
   assert.strictEqual(redirect, '/login?redirectTo=%2Fboards')
+  globalThis.fetch = realFetch
+})
+
+test('logout clears auth even on failure', async () => {
+  login()
+  const realFetch = globalThis.fetch
+  globalThis.fetch = async () => { throw new Error('net') }
+  await logout().catch(() => {})
+  assert.strictEqual(isAuthenticated(), false)
+  globalThis.fetch = realFetch
 })

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,8 +1,25 @@
 import { useState } from 'react'
+import { isAuthenticated, logout } from '../auth.js'
+import { navigate } from '../router.js'
 
 // Top navigation bar with brand and responsive burger menu
 export default function Header() {
   const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const authed = isAuthenticated()
+
+  const handleLogout = async () => {
+    if (loading) return
+    setLoading(true)
+    try {
+      await logout()
+    } catch (e) {
+      window.alert('Не удалось выйти, попробуйте ещё раз')
+    } finally {
+      setLoading(false)
+      navigate('/login')
+    }
+  }
 
   return (
     <header className="bg-gray-800 px-4 py-3 flex items-center justify-between relative">
@@ -11,6 +28,16 @@ export default function Header() {
       {/* Desktop navigation */}
       <nav className="hidden md:flex gap-4 items-center">
         <a href="#" className="hover:text-blue-400">Room-1234</a>
+        {authed && (
+          <button
+            onClick={handleLogout}
+            disabled={loading}
+            className="flex items-center gap-1 hover:text-blue-400"
+          >
+            <span aria-hidden="true">⇦</span>
+            Выйти
+          </button>
+        )}
       </nav>
 
       {/* Burger menu for mobile */}
@@ -32,6 +59,15 @@ export default function Header() {
           >
             Room-1234
           </a>
+          {authed && (
+            <button
+              onClick={handleLogout}
+              disabled={loading}
+              className="block py-1 w-full text-left hover:text-blue-400"
+            >
+              Выйти
+            </button>
+          )}
         </div>
       )}
     </header>

--- a/src/main/java/com/zherikhov/planningpoker/api/auth/AuthController.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/AuthController.java
@@ -4,12 +4,12 @@ import com.zherikhov.planningpoker.infrastructure.security.JwtProvider;
 import com.zherikhov.planningpoker.application.auth.RegistrationService;
 import com.zherikhov.planningpoker.api.auth.UserResponse;
 import com.zherikhov.planningpoker.api.auth.RegisterRequest;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -74,11 +74,15 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response) {
-        Cookie cookie = new Cookie("refreshToken", "");
-        cookie.setPath("/api/auth/refresh");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-        return ResponseEntity.ok().build();
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/auth/refresh")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")

--- a/src/test/java/com/zherikhov/planningpoker/api/auth/AuthControllerTest.java
+++ b/src/test/java/com/zherikhov/planningpoker/api/auth/AuthControllerTest.java
@@ -3,16 +3,19 @@ package com.zherikhov.planningpoker.api.auth;
 import com.zherikhov.planningpoker.api.auth.EmailAlreadyExistsException;
 import com.zherikhov.planningpoker.api.auth.UserResponse;
 import com.zherikhov.planningpoker.application.auth.RegistrationService;
+import com.zherikhov.planningpoker.infrastructure.security.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -26,6 +29,9 @@ class AuthControllerTest {
 
     @MockBean
     private RegistrationService registrationService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
 
     @Test
     void register_ReturnsCreatedUser() throws Exception {
@@ -58,5 +64,13 @@ class AuthControllerTest {
                         .content("{\"email\":\"bad\",\"password\":\"123\",\"displayName\":\"V\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void logout_ClearsRefreshCookie() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Max-Age=0")))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")));
     }
 }


### PR DESCRIPTION
## Summary
- implement backend logout endpoint that clears refresh cookie
- add logout button and client auth cleanup
- document authentication endpoints

## Testing
- `npm test`
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68af4eb32dc083228f6b974c3bb37b39