### PR TITLE
Fix login error handling and add auth guard

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -20,9 +20,21 @@ if (typeof globalThis.sessionStorage === 'undefined') {
   globalThis.sessionStorage = memoryStorage()
 }
 
-export function login(remember = false) {
+const TOKEN_KEY = 'accessToken'
+const EXP_KEY = 'expiresAt'
+
+export function login(token, expiresIn, remember = false) {
   const storage = remember ? localStorage : sessionStorage
-  storage.setItem('auth', 'true')
+  const expiresAt = Date.now() + expiresIn * 1000
+  storage.setItem(TOKEN_KEY, token)
+  storage.setItem(EXP_KEY, String(expiresAt))
+}
+
+export function clearAuth() {
+  localStorage.removeItem(TOKEN_KEY)
+  localStorage.removeItem(EXP_KEY)
+  sessionStorage.removeItem(TOKEN_KEY)
+  sessionStorage.removeItem(EXP_KEY)
 }
 
 export async function logout() {
@@ -38,22 +50,58 @@ export async function logout() {
   } catch (e) {
     error = e
   } finally {
-    localStorage.removeItem('auth')
-    sessionStorage.removeItem('auth')
+    clearAuth()
   }
   if (error) throw error
 }
 
-export function isAuthenticated() {
-  return (
-    localStorage.getItem('auth') === 'true' ||
-    sessionStorage.getItem('auth') === 'true'
-  )
+function getStoredAuth() {
+  const localToken = localStorage.getItem(TOKEN_KEY)
+  if (localToken) return { token: localToken, exp: parseInt(localStorage.getItem(EXP_KEY), 10), storage: localStorage }
+  const sessionToken = sessionStorage.getItem(TOKEN_KEY)
+  if (sessionToken) return { token: sessionToken, exp: parseInt(sessionStorage.getItem(EXP_KEY), 10), storage: sessionStorage }
+  return null
+}
+
+export async function isAuthenticated() {
+  const auth = getStoredAuth()
+  if (!auth || !auth.token) return false
+  if (!auth.exp || Date.now() >= auth.exp) {
+    try {
+      const res = await fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' })
+      if (res.ok) {
+        const data = await res.json()
+        login(data.accessToken, data.expiresIn, auth.storage === localStorage)
+        return true
+      }
+    } catch (e) {
+      // ignore network errors
+    }
+    clearAuth()
+    return false
+  }
+  return true
 }
 
 // Guard helper: returns redirect path when not authenticated
-export function ensureAuth(targetPath) {
-  return isAuthenticated()
+export async function ensureAuth(targetPath) {
+  return (await isAuthenticated())
     ? null
     : `/login?redirectTo=${encodeURIComponent(targetPath)}`
+}
+
+export async function loginUser({ email, password, remember, navigate, redirectTo }, fetchImpl = fetch) {
+  const res = await fetchImpl('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+    credentials: 'include'
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: 'Login failed' }))
+    throw err
+  }
+  const data = await res.json()
+  login(data.accessToken, data.expiresIn, remember)
+  navigate(redirectTo || '/boards')
 }

--- a/frontend/src/auth.test.js
+++ b/frontend/src/auth.test.js
@@ -8,9 +8,9 @@ test('login and isAuthenticated', async () => {
   const realFetch = globalThis.fetch
   globalThis.fetch = async () => ({ ok: true, status: 204 })
   await logout().catch(() => {})
-  assert.strictEqual(isAuthenticated(), false)
-  login()
-  assert.strictEqual(isAuthenticated(), true)
+  assert.strictEqual(await isAuthenticated(), false)
+  login('t', 60)
+  assert.strictEqual(await isAuthenticated(), true)
   globalThis.fetch = realFetch
 })
 
@@ -18,16 +18,16 @@ test('ensureAuth builds redirect path', async () => {
   const realFetch = globalThis.fetch
   globalThis.fetch = async () => ({ ok: true, status: 204 })
   await logout().catch(() => {})
-  const redirect = ensureAuth('/boards')
+  const redirect = await ensureAuth('/boards')
   assert.strictEqual(redirect, '/login?redirectTo=%2Fboards')
   globalThis.fetch = realFetch
 })
 
 test('logout clears auth even on failure', async () => {
-  login()
+  login('t', 60)
   const realFetch = globalThis.fetch
   globalThis.fetch = async () => { throw new Error('net') }
   await logout().catch(() => {})
-  assert.strictEqual(isAuthenticated(), false)
+  assert.strictEqual(await isAuthenticated(), false)
   globalThis.fetch = realFetch
 })

--- a/frontend/src/login.test.js
+++ b/frontend/src/login.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { loginUser, logout, isAuthenticated } from './auth.js'
+
+// Test login handler behaviour
+
+test('loginUser does not navigate on failure', async () => {
+  const fetchImpl = async () => ({ ok: false, json: async () => ({ error: 'INVALID_CREDENTIALS' }) })
+  let navCalled = false
+  const navigate = () => { navCalled = true }
+  await logout().catch(() => {})
+  await assert.rejects(() => loginUser({ email: 'a', password: 'b', remember: false, navigate, redirectTo: '/boards' }, fetchImpl))
+  assert.strictEqual(navCalled, false)
+  assert.strictEqual(await isAuthenticated(), false)
+})
+
+test('loginUser navigates on success', async () => {
+  const fetchImpl = async () => ({ ok: true, json: async () => ({ accessToken: 'tok', expiresIn: 60 }) })
+  let dest = null
+  const navigate = (to) => { dest = to }
+  await logout().catch(() => {})
+  await loginUser({ email: 'a', password: 'b', remember: false, navigate, redirectTo: '/boards' }, fetchImpl)
+  assert.strictEqual(dest, '/boards')
+  assert.strictEqual(await isAuthenticated(), true)
+})


### PR DESCRIPTION
## Summary
- handle /api/auth/login errors without navigating away from /login
- store auth tokens with expiry and enforce access guards
- add unit tests for login handler and auth utilities

## Testing
- `npm test`
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68af5ead620883229f2e9ada2ccaa134