### PR TITLE
Fix login redirect and error handling

### DIFF
--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -91,7 +91,8 @@ export default function Login() {
     const params = new URLSearchParams(window.location.search)
     const redirect = params.get('redirectTo') || '/boards'
     try {
-      await loginUser({ email, password, remember, navigate, redirectTo: redirect })
+      await loginUser({ email, password, remember })
+      navigate(redirect)
     } catch (err) {
       const message = err instanceof Error ? t.errorNetwork : mapApiError(err)
       setAlert(message)

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -90,7 +90,7 @@ export async function ensureAuth(targetPath) {
     : `/login?redirectTo=${encodeURIComponent(targetPath)}`
 }
 
-export async function loginUser({ email, password, remember, navigate, redirectTo }, fetchImpl = fetch) {
+export async function loginUser({ email, password, remember }, fetchImpl = fetch) {
   const res = await fetchImpl('/api/auth/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -98,10 +98,10 @@ export async function loginUser({ email, password, remember, navigate, redirectT
     credentials: 'include'
   })
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ message: 'Login failed' }))
+    const err = await res.json().catch(() => ({}))
     throw err
   }
   const data = await res.json()
   login(data.accessToken, data.expiresIn, remember)
-  navigate(redirectTo || '/boards')
+  return data
 }

--- a/frontend/src/login.test.js
+++ b/frontend/src/login.test.js
@@ -2,24 +2,19 @@ import test from 'node:test'
 import assert from 'node:assert'
 import { loginUser, logout, isAuthenticated } from './auth.js'
 
-// Test login handler behaviour
+// Test login helper behaviour
 
-test('loginUser does not navigate on failure', async () => {
+test('loginUser rejects on failure', async () => {
   const fetchImpl = async () => ({ ok: false, json: async () => ({ error: 'INVALID_CREDENTIALS' }) })
-  let navCalled = false
-  const navigate = () => { navCalled = true }
   await logout().catch(() => {})
-  await assert.rejects(() => loginUser({ email: 'a', password: 'b', remember: false, navigate, redirectTo: '/boards' }, fetchImpl))
-  assert.strictEqual(navCalled, false)
+  await assert.rejects(() => loginUser({ email: 'a', password: 'b', remember: false }, fetchImpl))
   assert.strictEqual(await isAuthenticated(), false)
 })
 
-test('loginUser navigates on success', async () => {
+test('loginUser authenticates on success', async () => {
   const fetchImpl = async () => ({ ok: true, json: async () => ({ accessToken: 'tok', expiresIn: 60 }) })
-  let dest = null
-  const navigate = (to) => { dest = to }
   await logout().catch(() => {})
-  await loginUser({ email: 'a', password: 'b', remember: false, navigate, redirectTo: '/boards' }, fetchImpl)
-  assert.strictEqual(dest, '/boards')
+  const data = await loginUser({ email: 'a', password: 'b', remember: false }, fetchImpl)
+  assert.strictEqual(data.accessToken, 'tok')
   assert.strictEqual(await isAuthenticated(), true)
 })


### PR DESCRIPTION
## Summary
- revise auth helper to return login data and stop navigating internally
- update login form to redirect after successful auth and stay on /login with error on failure
- adjust unit tests for new login helper behavior

## Testing
- `npm test`
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*


------
https://chatgpt.com/codex/tasks/task_e_68afe4f18ef0832290fe5ea7fb839161