### PR TITLE
feat: add domain layer skeleton

### DIFF
--- a/src/main/java/com/zherikhov/planningpoker/domain/common/DomainException.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/common/DomainException.java
@@ -1,0 +1,14 @@
+package com.zherikhov.planningpoker.domain.common;
+
+/**
+ * Base type for all domain-specific runtime exceptions.
+ */
+public class DomainException extends RuntimeException {
+    public DomainException(String message) {
+        super(message);
+    }
+
+    public DomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/eventlog/EventLog.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/eventlog/EventLog.java
@@ -1,0 +1,15 @@
+package com.zherikhov.planningpoker.domain.eventlog;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Technical event captured for auditing.
+ */
+public record EventLog(
+        UUID id,
+        String type,
+        String payload,
+        Instant timestamp
+) {
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/room/Room.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/room/Room.java
@@ -1,0 +1,19 @@
+package com.zherikhov.planningpoker.domain.room;
+
+import com.zherikhov.planningpoker.domain.user.User;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Domain aggregate representing a planning room.
+ */
+public record Room(
+        UUID id,
+        String name,
+        String code,
+        User owner,
+        List<User> participants,
+        List<Integer> deck
+) {
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/task/Task.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/task/Task.java
@@ -1,0 +1,17 @@
+package com.zherikhov.planningpoker.domain.task;
+
+import java.util.UUID;
+
+/**
+ * Domain aggregate for a planning task.
+ */
+public record Task(
+        UUID id,
+        UUID roomId,
+        String title,
+        String description,
+        UUID authorUserId,
+        TaskStatus status,
+        Integer finalValue
+) {
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/task/TaskStatus.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/task/TaskStatus.java
@@ -1,0 +1,11 @@
+package com.zherikhov.planningpoker.domain.task;
+
+/**
+ * Lifecycle states of a task during planning poker.
+ */
+public enum TaskStatus {
+    NEW,
+    ESTIMATING,
+    REVEALED,
+    FINALIZED
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/user/Role.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/user/Role.java
@@ -1,0 +1,9 @@
+package com.zherikhov.planningpoker.domain.user;
+
+/**
+ * User roles within the system.
+ */
+public enum Role {
+    USER,
+    MODERATOR
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/user/User.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/user/User.java
@@ -1,0 +1,14 @@
+package com.zherikhov.planningpoker.domain.user;
+
+import java.util.UUID;
+
+/**
+ * Domain representation of an application user.
+ */
+public record User(
+        UUID id,
+        String email,
+        String displayName,
+        Role role
+) {
+}

--- a/src/main/java/com/zherikhov/planningpoker/domain/voting/Vote.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/voting/Vote.java
@@ -1,0 +1,13 @@
+package com.zherikhov.planningpoker.domain.voting;
+
+import java.util.UUID;
+
+/**
+ * Represents a participant's vote for a task.
+ */
+public record Vote(
+        UUID taskId,
+        UUID participantId,
+        Integer value
+) {
+}


### PR DESCRIPTION
## Summary
- add base domain packages and aggregate records for user, room, task, vote, and event log
- introduce common DomainException

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network offline)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e54df20483229c6d03f2a15ad9c9