### PR TITLE
Introduce application-level services for auth and room queries

### DIFF
--- a/src/main/java/com/zherikhov/planningpoker/api/auth/AuthController.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/AuthController.java
@@ -1,10 +1,11 @@
 package com.zherikhov.planningpoker.api.auth;
 
-import com.zherikhov.planningpoker.infrastructure.security.JwtProvider;
+import com.zherikhov.planningpoker.application.auth.AuthService;
 import com.zherikhov.planningpoker.application.auth.RegistrationService;
 import com.zherikhov.planningpoker.api.auth.UserResponse;
 import com.zherikhov.planningpoker.api.auth.RegisterRequest;
-import jakarta.servlet.http.Cookie;
+import com.zherikhov.planningpoker.api.auth.LoginRequest;
+import com.zherikhov.planningpoker.api.auth.LoginResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
@@ -23,38 +24,23 @@ import java.util.Map;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final JwtProvider jwtProvider;
+    private final AuthService authService;
     private final RegistrationService registrationService;
 
-    public AuthController(JwtProvider jwtProvider, RegistrationService registrationService) {
-        this.jwtProvider = jwtProvider;
+    public AuthController(AuthService authService, RegistrationService registrationService) {
+        this.authService = authService;
         this.registrationService = registrationService;
     }
 
-    private static final String DEMO_EMAIL = "user@example.com";
-    private static final String DEMO_PASSWORD = "secret";
-    private static final UserDto DEMO_USER = new UserDto("1", DEMO_EMAIL, "Demo User");
-
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpServletResponse response) {
-        if (DEMO_EMAIL.equals(request.email()) && DEMO_PASSWORD.equals(request.password())) {
-            String token = jwtProvider.generateToken(DEMO_USER.id());
-            if (request.rememberMe()) {
-                Cookie cookie = new Cookie("refreshToken", token);
-                cookie.setHttpOnly(true);
-                cookie.setSecure(true);
-                cookie.setPath("/api/auth/refresh");
-                cookie.setMaxAge(2592000); // 30 days
-                response.addCookie(cookie);
-            }
-            LoginResponse body = new LoginResponse(token, 3600, DEMO_USER);
-            return ResponseEntity.ok(body);
-        }
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(Map.of(
-                        "error", "INVALID_CREDENTIALS",
-                        "message", "Email or password is incorrect"
-                ));
+        return authService.login(request, response)
+                .<ResponseEntity<?>>map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Map.of(
+                                "error", "INVALID_CREDENTIALS",
+                                "message", "Email or password is incorrect"
+                        )));
     }
 
     @PostMapping("/register")
@@ -65,12 +51,10 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(@CookieValue(value = "refreshToken", required = false) String refreshToken) {
-        if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", "NO_REFRESH", "message", "Missing refresh token"));
-        }
-        String token = jwtProvider.generateToken(DEMO_USER.id());
-        return ResponseEntity.ok(Map.of("accessToken", token, "expiresIn", 3600));
+        return authService.refresh(refreshToken)
+                .<ResponseEntity<?>>map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Map.of("error", "NO_REFRESH", "message", "Missing refresh token")));
     }
 
     @PostMapping("/logout")
@@ -88,20 +72,8 @@ public class AuthController {
 
     @GetMapping("/me")
     public ResponseEntity<?> me(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-        String token = authHeader.substring(7);
-        try {
-            jwtProvider.getSubject(token);
-            return ResponseEntity.ok(Map.of("user", DEMO_USER));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+        return authService.me(authHeader)
+                .<ResponseEntity<?>>map(u -> ResponseEntity.ok(Map.of("user", u)))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
     }
-
-    // request/response records
-    public record LoginRequest(String email, String password, boolean rememberMe) {}
-    public record UserDto(String id, String email, String displayName) {}
-    public record LoginResponse(String accessToken, int expiresIn, UserDto user) {}
 }

--- a/src/main/java/com/zherikhov/planningpoker/api/auth/LoginRequest.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/LoginRequest.java
@@ -1,0 +1,3 @@
+package com.zherikhov.planningpoker.api.auth;
+
+public record LoginRequest(String email, String password, boolean rememberMe) {}

--- a/src/main/java/com/zherikhov/planningpoker/api/auth/LoginResponse.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.zherikhov.planningpoker.api.auth;
+
+public record LoginResponse(String accessToken, int expiresIn, UserResponse user) {}

--- a/src/main/java/com/zherikhov/planningpoker/api/rooms/RoomController.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/rooms/RoomController.java
@@ -1,8 +1,8 @@
 package com.zherikhov.planningpoker.api.rooms;
 
 import com.zherikhov.planningpoker.application.rooms.CreateRoomService;
+import com.zherikhov.planningpoker.application.rooms.RoomQueryService;
 import com.zherikhov.planningpoker.domain.rooms.Room;
-import com.zherikhov.planningpoker.infrastructure.persistence.service.RoomService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,11 +21,11 @@ import java.util.List;
 public class RoomController {
 
     private final CreateRoomService createRoomService;
-    private final RoomService roomService;
+    private final RoomQueryService roomQueryService;
 
-    public RoomController(CreateRoomService createRoomService, RoomService roomService) {
+    public RoomController(CreateRoomService createRoomService, RoomQueryService roomQueryService) {
         this.createRoomService = createRoomService;
-        this.roomService = roomService;
+        this.roomQueryService = roomQueryService;
     }
 
     @PostMapping
@@ -37,8 +37,8 @@ public class RoomController {
 
     @GetMapping
     public ResponseEntity<List<RoomDto>> getRooms() {
-        List<RoomDto> rooms = roomService.findAll().stream()
-                .map(e -> new RoomDto(e.getId(), e.getName(), e.getStatus()))
+        List<RoomDto> rooms = roomQueryService.findAll().stream()
+                .map(e -> new RoomDto(e.id().value(), e.name(), e.status().name()))
                 .toList();
         return ResponseEntity.ok(rooms);
     }

--- a/src/main/java/com/zherikhov/planningpoker/application/auth/AuthService.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/auth/AuthService.java
@@ -1,0 +1,15 @@
+package com.zherikhov.planningpoker.application.auth;
+
+import com.zherikhov.planningpoker.api.auth.LoginRequest;
+import com.zherikhov.planningpoker.api.auth.LoginResponse;
+import com.zherikhov.planningpoker.api.auth.UserResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface AuthService {
+    Optional<LoginResponse> login(LoginRequest request, HttpServletResponse response);
+    Optional<Map<String, Object>> refresh(String refreshToken);
+    Optional<UserResponse> me(String authHeader);
+}

--- a/src/main/java/com/zherikhov/planningpoker/application/rooms/RoomQueryService.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/rooms/RoomQueryService.java
@@ -1,0 +1,9 @@
+package com.zherikhov.planningpoker.application.rooms;
+
+import com.zherikhov.planningpoker.domain.rooms.Room;
+
+import java.util.List;
+
+public interface RoomQueryService {
+    List<Room> findAll();
+}

--- a/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/service/RoomService.java
+++ b/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/service/RoomService.java
@@ -1,5 +1,9 @@
 package com.zherikhov.planningpoker.infrastructure.persistence.service;
 
+import com.zherikhov.planningpoker.application.rooms.RoomQueryService;
+import com.zherikhov.planningpoker.domain.rooms.Room;
+import com.zherikhov.planningpoker.domain.rooms.RoomId;
+import com.zherikhov.planningpoker.domain.rooms.RoomStatus;
 import com.zherikhov.planningpoker.infrastructure.persistence.dao.RoomJpaRepository;
 import com.zherikhov.planningpoker.infrastructure.persistence.entity.RoomEntity;
 import org.springframework.stereotype.Service;
@@ -8,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-public class RoomService {
+public class RoomService implements RoomQueryService {
     private final RoomJpaRepository repository;
 
     public RoomService(RoomJpaRepository repository) {
@@ -23,8 +27,11 @@ public class RoomService {
         return repository.findById(id);
     }
 
-    public List<RoomEntity> findAll() {
-        return repository.findAll();
+    @Override
+    public List<Room> findAll() {
+        return repository.findAll().stream()
+                .map(e -> new Room(new RoomId(e.getId()), e.getName(), RoomStatus.valueOf(e.getStatus())))
+                .toList();
     }
 
     public void deleteById(String id) {

--- a/src/main/java/com/zherikhov/planningpoker/infrastructure/security/AuthServiceImpl.java
+++ b/src/main/java/com/zherikhov/planningpoker/infrastructure/security/AuthServiceImpl.java
@@ -1,0 +1,68 @@
+package com.zherikhov.planningpoker.infrastructure.security;
+
+import com.zherikhov.planningpoker.api.auth.LoginRequest;
+import com.zherikhov.planningpoker.api.auth.LoginResponse;
+import com.zherikhov.planningpoker.api.auth.UserResponse;
+import com.zherikhov.planningpoker.application.auth.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    private final JwtProvider jwtProvider;
+
+    private static final String DEMO_EMAIL = "user@example.com";
+    private static final String DEMO_PASSWORD = "secret";
+    private static final UserResponse DEMO_USER = new UserResponse(
+            UUID.fromString("00000000-0000-0000-0000-000000000001"), DEMO_EMAIL, "Demo User");
+
+    public AuthServiceImpl(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public Optional<LoginResponse> login(LoginRequest request, HttpServletResponse response) {
+        if (DEMO_EMAIL.equals(request.email()) && DEMO_PASSWORD.equals(request.password())) {
+            String token = jwtProvider.generateToken(DEMO_USER.id().toString());
+            if (request.rememberMe()) {
+                Cookie cookie = new Cookie("refreshToken", token);
+                cookie.setHttpOnly(true);
+                cookie.setSecure(true);
+                cookie.setPath("/api/auth/refresh");
+                cookie.setMaxAge(2592000); // 30 days
+                response.addCookie(cookie);
+            }
+            return Optional.of(new LoginResponse(token, 3600, DEMO_USER));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Map<String, Object>> refresh(String refreshToken) {
+        if (refreshToken == null) {
+            return Optional.empty();
+        }
+        String token = jwtProvider.generateToken(DEMO_USER.id().toString());
+        return Optional.of(Map.of("accessToken", token, "expiresIn", 3600));
+    }
+
+    @Override
+    public Optional<UserResponse> me(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return Optional.empty();
+        }
+        String token = authHeader.substring(7);
+        try {
+            jwtProvider.getSubject(token);
+            return Optional.of(DEMO_USER);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/com/zherikhov/planningpoker/api/auth/AuthControllerTest.java
+++ b/src/test/java/com/zherikhov/planningpoker/api/auth/AuthControllerTest.java
@@ -2,8 +2,8 @@ package com.zherikhov.planningpoker.api.auth;
 
 import com.zherikhov.planningpoker.api.auth.EmailAlreadyExistsException;
 import com.zherikhov.planningpoker.api.auth.UserResponse;
+import com.zherikhov.planningpoker.application.auth.AuthService;
 import com.zherikhov.planningpoker.application.auth.RegistrationService;
-import com.zherikhov.planningpoker.infrastructure.security.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +31,7 @@ class AuthControllerTest {
     private RegistrationService registrationService;
 
     @MockBean
-    private JwtProvider jwtProvider;
+    private AuthService authService;
 
     @Test
     void register_ReturnsCreatedUser() throws Exception {

--- a/src/test/java/com/zherikhov/planningpoker/api/rooms/RoomControllerTest.java
+++ b/src/test/java/com/zherikhov/planningpoker/api/rooms/RoomControllerTest.java
@@ -1,11 +1,10 @@
 package com.zherikhov.planningpoker.api.rooms;
 
 import com.zherikhov.planningpoker.application.rooms.CreateRoomService;
+import com.zherikhov.planningpoker.application.rooms.RoomQueryService;
 import com.zherikhov.planningpoker.domain.rooms.Room;
 import com.zherikhov.planningpoker.domain.rooms.RoomId;
 import com.zherikhov.planningpoker.domain.rooms.RoomStatus;
-import com.zherikhov.planningpoker.infrastructure.persistence.entity.RoomEntity;
-import com.zherikhov.planningpoker.infrastructure.persistence.service.RoomService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,7 +29,7 @@ class RoomControllerTest {
     private CreateRoomService createRoomService;
 
     @MockBean
-    private RoomService roomService;
+    private RoomQueryService roomQueryService;
 
     @Test
     void createRoom_ReturnsCreatedRoom() throws Exception {
@@ -56,8 +55,8 @@ class RoomControllerTest {
 
     @Test
     void getRooms_ReturnsListOfRooms() throws Exception {
-        RoomEntity entity = new RoomEntity("id1", "Room1", "OPEN");
-        when(roomService.findAll()).thenReturn(List.of(entity));
+        Room room = new Room(new RoomId("id1"), "Room1", RoomStatus.OPEN);
+        when(roomQueryService.findAll()).thenReturn(List.of(room));
 
         mockMvc.perform(get("/api/rooms"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- add `RoomQueryService` and inject into `RoomController`
- add `AuthService` with JWT-based implementation and use in `AuthController`
- define `LoginRequest` and `LoginResponse` API models

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3164f8d248322b3c0b74402f61931