### PR TITLE
Use application models for registration

### DIFF
--- a/src/main/java/com/zherikhov/planningpoker/api/auth/AuthController.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/AuthController.java
@@ -1,9 +1,11 @@
 package com.zherikhov.planningpoker.api.auth;
 
 import com.zherikhov.planningpoker.infrastructure.security.JwtProvider;
+import com.zherikhov.planningpoker.application.auth.RegisterUser;
 import com.zherikhov.planningpoker.application.auth.RegistrationService;
 import com.zherikhov.planningpoker.api.auth.UserResponse;
 import com.zherikhov.planningpoker.api.auth.RegisterRequest;
+import com.zherikhov.planningpoker.domain.user.User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -59,8 +61,10 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<UserResponse> register(@Valid @RequestBody RegisterRequest request) {
-        UserResponse user = registrationService.register(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(user);
+        RegisterUser command = new RegisterUser(request.email(), request.password(), request.displayName());
+        User user = registrationService.register(command);
+        UserResponse response = new UserResponse(user.id(), user.email(), user.displayName());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/zherikhov/planningpoker/api/auth/EmailAlreadyExistsException.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/EmailAlreadyExistsException.java
@@ -1,7 +1,0 @@
-package com.zherikhov.planningpoker.api.auth;
-
-public class EmailAlreadyExistsException extends RuntimeException {
-    public EmailAlreadyExistsException(String email) {
-        super("Email already registered: " + email);
-    }
-}

--- a/src/main/java/com/zherikhov/planningpoker/api/auth/RestExceptionHandler.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/auth/RestExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.zherikhov.planningpoker.api.auth;
 
+import com.zherikhov.planningpoker.application.auth.EmailAlreadyExistsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;

--- a/src/main/java/com/zherikhov/planningpoker/application/auth/EmailAlreadyExistsException.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/auth/EmailAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.zherikhov.planningpoker.application.auth;
+
+import com.zherikhov.planningpoker.domain.common.DomainException;
+
+/**
+ * Thrown when attempting to register with an email that already exists.
+ */
+public class EmailAlreadyExistsException extends DomainException {
+    public EmailAlreadyExistsException(String email) {
+        super("Email already registered: " + email);
+    }
+}

--- a/src/main/java/com/zherikhov/planningpoker/application/auth/RegisterUser.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/auth/RegisterUser.java
@@ -1,0 +1,6 @@
+package com.zherikhov.planningpoker.application.auth;
+
+/**
+ * Command object for registering a new user.
+ */
+public record RegisterUser(String email, String password, String displayName) {}

--- a/src/main/java/com/zherikhov/planningpoker/application/auth/RegistrationService.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/auth/RegistrationService.java
@@ -1,8 +1,16 @@
 package com.zherikhov.planningpoker.application.auth;
 
-import com.zherikhov.planningpoker.api.auth.RegisterRequest;
-import com.zherikhov.planningpoker.api.auth.UserResponse;
+import com.zherikhov.planningpoker.domain.user.User;
 
+/**
+ * Service for registering new users.
+ */
 public interface RegistrationService {
-    UserResponse register(RegisterRequest req);
+    /**
+     * Registers a new user based on the provided command.
+     *
+     * @param req registration data
+     * @return created user domain model
+     */
+    User register(RegisterUser req);
 }

--- a/src/main/java/com/zherikhov/planningpoker/application/auth/RegistrationServiceImpl.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/auth/RegistrationServiceImpl.java
@@ -1,8 +1,7 @@
 package com.zherikhov.planningpoker.application.auth;
 
-import com.zherikhov.planningpoker.api.auth.EmailAlreadyExistsException;
-import com.zherikhov.planningpoker.api.auth.RegisterRequest;
-import com.zherikhov.planningpoker.api.auth.UserResponse;
+import com.zherikhov.planningpoker.domain.user.Role;
+import com.zherikhov.planningpoker.domain.user.User;
 import com.zherikhov.planningpoker.infrastructure.persistence.entity.AppUserEntity;
 import com.zherikhov.planningpoker.infrastructure.persistence.dao.AppUserJpaRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -24,7 +23,7 @@ public class RegistrationServiceImpl implements RegistrationService {
 
     @Override
     @Transactional
-    public UserResponse register(RegisterRequest req) {
+    public User register(RegisterUser req) {
         String email = req.email().trim().toLowerCase();
         String displayName = req.displayName().trim();
         if (repository.existsByEmailIgnoreCase(email)) {
@@ -41,6 +40,6 @@ public class RegistrationServiceImpl implements RegistrationService {
         entity.setCreatedAt(now);
         entity.setUpdatedAt(now);
         AppUserEntity saved = repository.save(entity);
-        return new UserResponse(UUID.fromString(saved.getId()), saved.getEmail(), saved.getDisplayName());
+        return new User(UUID.fromString(saved.getId()), saved.getEmail(), saved.getDisplayName(), Role.valueOf(saved.getRole()));
     }
 }

--- a/src/test/java/com/zherikhov/planningpoker/api/auth/AuthControllerTest.java
+++ b/src/test/java/com/zherikhov/planningpoker/api/auth/AuthControllerTest.java
@@ -1,8 +1,9 @@
 package com.zherikhov.planningpoker.api.auth;
 
-import com.zherikhov.planningpoker.api.auth.EmailAlreadyExistsException;
-import com.zherikhov.planningpoker.api.auth.UserResponse;
+import com.zherikhov.planningpoker.application.auth.EmailAlreadyExistsException;
 import com.zherikhov.planningpoker.application.auth.RegistrationService;
+import com.zherikhov.planningpoker.domain.user.Role;
+import com.zherikhov.planningpoker.domain.user.User;
 import com.zherikhov.planningpoker.infrastructure.security.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,7 +36,7 @@ class AuthControllerTest {
 
     @Test
     void register_ReturnsCreatedUser() throws Exception {
-        when(registrationService.register(any())).thenReturn(new UserResponse(UUID.randomUUID(), "new@example.com", "Vlad"));
+        when(registrationService.register(any())).thenReturn(new User(UUID.randomUUID(), "new@example.com", "Vlad", Role.USER));
 
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/zherikhov/planningpoker/application/auth/RegistrationServiceTest.java
+++ b/src/test/java/com/zherikhov/planningpoker/application/auth/RegistrationServiceTest.java
@@ -1,8 +1,7 @@
 package com.zherikhov.planningpoker.application.auth;
 
-import com.zherikhov.planningpoker.api.auth.EmailAlreadyExistsException;
-import com.zherikhov.planningpoker.api.auth.RegisterRequest;
-import com.zherikhov.planningpoker.api.auth.UserResponse;
+import com.zherikhov.planningpoker.domain.user.Role;
+import com.zherikhov.planningpoker.domain.user.User;
 import com.zherikhov.planningpoker.infrastructure.persistence.entity.AppUserEntity;
 import com.zherikhov.planningpoker.infrastructure.persistence.dao.AppUserJpaRepository;
 import org.junit.jupiter.api.Test;
@@ -34,10 +33,11 @@ class RegistrationServiceTest {
         saved.setUpdatedAt(saved.getCreatedAt());
         when(repository.save(captor.capture())).thenReturn(saved);
 
-        UserResponse res = service.register(new RegisterRequest("new@example.com", "Secret123", "Vlad"));
+        User res = service.register(new RegisterUser("new@example.com", "Secret123", "Vlad"));
 
         assertEquals("new@example.com", res.email());
         assertEquals("Vlad", res.displayName());
+        assertEquals(Role.USER, res.role());
         AppUserEntity toSave = captor.getValue();
         assertEquals("USER", toSave.getRole());
         assertTrue(toSave.getPasswordHash() != null && !toSave.getPasswordHash().equals("Secret123"));
@@ -47,7 +47,7 @@ class RegistrationServiceTest {
     void register_duplicateEmail() {
         when(repository.existsByEmailIgnoreCase("user@example.com")).thenReturn(true);
         assertThrows(EmailAlreadyExistsException.class,
-                () -> service.register(new RegisterRequest("user@example.com", "Secret123", "Vlad")));
+                () -> service.register(new RegisterUser("user@example.com", "Secret123", "Vlad")));
         verify(repository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- Introduce application-level `RegisterUser` command and `EmailAlreadyExistsException`
- Refactor registration service to use domain `User` and new types
- Convert API DTOs to domain models in `AuthController`
- Update controller advice and tests for new exception and models

## Testing
- `./mvnw -q -o test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b3168a6f608322a0ae7eb0ac4fe8b7