### PR TITLE
Add optional room description

### DIFF
--- a/src/main/java/com/zherikhov/planningpoker/api/rooms/RoomController.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/rooms/RoomController.java
@@ -30,15 +30,15 @@ public class RoomController {
 
     @PostMapping
     public ResponseEntity<RoomDto> createRoom(@Valid @RequestBody RoomDto request) {
-        Room room = createRoomService.createRoom(request.name());
+        Room room = createRoomService.createRoom(request.name(), request.description());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new RoomDto(room.id().value(), room.name(), room.status().name()));
+                .body(new RoomDto(room.id().value(), room.name(), room.description(), room.status().name()));
     }
 
     @GetMapping
     public ResponseEntity<List<RoomDto>> getRooms() {
         List<RoomDto> rooms = roomQueryService.findAll().stream()
-                .map(e -> new RoomDto(e.id().value(), e.name(), e.status().name()))
+                .map(e -> new RoomDto(e.id().value(), e.name(), e.description(), e.status().name()))
                 .toList();
         return ResponseEntity.ok(rooms);
     }

--- a/src/main/java/com/zherikhov/planningpoker/api/rooms/RoomDto.java
+++ b/src/main/java/com/zherikhov/planningpoker/api/rooms/RoomDto.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Size;
 public record RoomDto(
         String id,
         @NotBlank @Size(min = 1, max = 80) String name,
+        @Size(max = 255) String description,
         String status
 ) {
 }

--- a/src/main/java/com/zherikhov/planningpoker/application/rooms/CreateRoomService.java
+++ b/src/main/java/com/zherikhov/planningpoker/application/rooms/CreateRoomService.java
@@ -17,8 +17,8 @@ public class CreateRoomService {
         this.roomRepository = roomRepository;
     }
 
-    public Room createRoom(String name) {
-        Room room = new Room(new RoomId(UUID.randomUUID().toString()), name, RoomStatus.OPEN);
+    public Room createRoom(String name, String description) {
+        Room room = new Room(new RoomId(UUID.randomUUID().toString()), name, description, RoomStatus.OPEN);
         return roomRepository.save(room);
     }
 }

--- a/src/main/java/com/zherikhov/planningpoker/domain/rooms/Room.java
+++ b/src/main/java/com/zherikhov/planningpoker/domain/rooms/Room.java
@@ -6,11 +6,13 @@ public class Room {
 
     private final RoomId id;
     private final String name;
+    private final String description;
     private final RoomStatus status;
 
-    public Room(RoomId id, String name, RoomStatus status) {
+    public Room(RoomId id, String name, String description, RoomStatus status) {
         this.id = id;
         this.name = name;
+        this.description = description;
         this.status = status;
     }
 
@@ -20,6 +22,10 @@ public class Room {
 
     public String name() {
         return name;
+    }
+
+    public String description() {
+        return description;
     }
 
     public RoomStatus status() {

--- a/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/entity/RoomEntity.java
+++ b/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/entity/RoomEntity.java
@@ -13,14 +13,17 @@ public class RoomEntity {
 
     private String name;
 
+    private String description;
+
     private String status;
 
     public RoomEntity() {
     }
 
-    public RoomEntity(String id, String name, String status) {
+    public RoomEntity(String id, String name, String description, String status) {
         this.id = id;
         this.name = name;
+        this.description = description;
         this.status = status;
     }
 
@@ -38,6 +41,14 @@ public class RoomEntity {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String getStatus() {

--- a/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/service/RoomService.java
+++ b/src/main/java/com/zherikhov/planningpoker/infrastructure/persistence/service/RoomService.java
@@ -21,15 +21,15 @@ public class RoomService implements RoomRepository, RoomQueryService {
 
     @Override
     public Room save(Room room) {
-        RoomEntity entity = new RoomEntity(room.id().value(), room.name(), room.status().name());
+        RoomEntity entity = new RoomEntity(room.id().value(), room.name(), room.description(), room.status().name());
         RoomEntity saved = repository.save(entity);
-        return new Room(new RoomId(saved.getId()), saved.getName(), RoomStatus.valueOf(saved.getStatus()));
+        return new Room(new RoomId(saved.getId()), saved.getName(), saved.getDescription(), RoomStatus.valueOf(saved.getStatus()));
     }
 
     @Override
     public List<Room> findAll() {
         return repository.findAll().stream()
-                .map(e -> new Room(new RoomId(e.getId()), e.getName(), RoomStatus.valueOf(e.getStatus())))
+                .map(e -> new Room(new RoomId(e.getId()), e.getName(), e.getDescription(), RoomStatus.valueOf(e.getStatus())))
                 .toList();
     }
 }

--- a/src/main/resources/db/migration/V3__add_room_description.sql
+++ b/src/main/resources/db/migration/V3__add_room_description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rooms ADD COLUMN description TEXT;

--- a/src/test/java/com/zherikhov/planningpoker/api/rooms/RoomControllerTest.java
+++ b/src/test/java/com/zherikhov/planningpoker/api/rooms/RoomControllerTest.java
@@ -33,15 +33,16 @@ class RoomControllerTest {
 
     @Test
     void createRoom_ReturnsCreatedRoom() throws Exception {
-        Room room = new Room(new RoomId("id1"), "Test room", RoomStatus.OPEN);
-        when(createRoomService.createRoom("Test room")).thenReturn(room);
+        Room room = new Room(new RoomId("id1"), "Test room", "Desc", RoomStatus.OPEN);
+        when(createRoomService.createRoom("Test room", "Desc")).thenReturn(room);
 
         mockMvc.perform(post("/api/rooms")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Test room\"}"))
+                        .content("{\"name\":\"Test room\",\"description\":\"Desc\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("id1"))
                 .andExpect(jsonPath("$.name").value("Test room"))
+                .andExpect(jsonPath("$.description").value("Desc"))
                 .andExpect(jsonPath("$.status").value("OPEN"));
     }
 
@@ -55,13 +56,14 @@ class RoomControllerTest {
 
     @Test
     void getRooms_ReturnsListOfRooms() throws Exception {
-        Room room = new Room(new RoomId("id1"), "Room1", RoomStatus.OPEN);
+        Room room = new Room(new RoomId("id1"), "Room1", "Desc1", RoomStatus.OPEN);
         when(roomQueryService.findAll()).thenReturn(List.of(room));
 
         mockMvc.perform(get("/api/rooms"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value("id1"))
                 .andExpect(jsonPath("$[0].name").value("Room1"))
+                .andExpect(jsonPath("$[0].description").value("Desc1"))
                 .andExpect(jsonPath("$[0].status").value("OPEN"));
     }
 }


### PR DESCRIPTION
## Summary
- allow rooms to store an optional description
- expose description in REST API and persistence
- migrate database schema with description column

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4b8c3cd48322a2d9bb745c4aa8b6